### PR TITLE
Build notpecl statically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,12 +106,11 @@ references:
       name: Build notpecl
       command: make build
 
-
   upload_bin_to_github_step: &upload_bin_to_github_step
     run:
       name: Upload notpecl binary to Github release
       command: |
-        GIT_TAG=${CIRCLE_TAG} NOTPECL_BIN=./notpecl make release
+        GIT_TAG=${CIRCLE_TAG} NOTPECL_BIN=.bin/notpecl make release
 
 jobs:
   test:
@@ -134,12 +133,6 @@ jobs:
     <<: *vm_machine
     steps:
       - <<: *checkout_step
-      - <<: *restore_cache_step
-      - <<: *install_newer_go_version
-      - <<: *fix_gopath_step
-      - <<: *create_gobin_step
-      - <<: *install_go_deps_step
-      - <<: *save_cache_step
       - <<: *build_notpecl_step
       - <<: *upload_bin_to_github_step
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*
+
+!backends/
+!cmd/
+!extindex/
+!ui/
+!go.mod
+!go.sum
+!main.go

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,20 @@
+FROM golang:1.13-alpine
+
+WORKDIR /app
+COPY . .
+
+ARG VERSION
+ARG COMMIT_HASH
+
+RUN apk add --no-cache --virtual=.build gcc musl-dev && \
+    go build -buildmode pie \
+        -ldflags "\
+            -linkmode external \
+            -extldflags '-static' \
+            -w -s \
+            -X 'github.com/NiR-/notpecl/cmd.releaseVersion=${VERSION}' \
+            -X 'github.com/NiR-/notpecl/cmd.commitHash=${COMMIT_HASH}'" \
+        -tags 'osusergo netgo static_build' \
+        . && \
+    apk del .build
+ 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+NO_CACHE ?= --no-cache
 export GO111MODULE=on
 
 # Used by go linker at build time to set the variables needed for `notpecl version`.
@@ -10,6 +11,7 @@ else
 endif
 endif
 
+
 # Either use `gotest` if available (same as `go test` but with colors), or use
 # `go test`.
 GOTEST := go test
@@ -19,11 +21,16 @@ endif
 
 .PHONY: build
 build:
-	go build -o .bin/notpecl -buildmode pie -ldflags "\
-		-w -s \
-		-X 'github.com/NiR-/notpecl/cmd.releaseVersion=$(VERSION)' \
-		-X 'github.com/NiR-/notpecl/cmd.commitHash=$(GIT_SHA1)' \
-	" .
+	docker build $(NO_CACHE) \
+		-f Dockerfile.build \
+		-t notpecl \
+		--build-arg "VERSION=$(VERSION)" \
+		--build-arg "COMMIT_HASH=$(GIT_SHA1)" \
+		.
+	docker run --rm \
+		-v $(PWD)/.bin:/mnt \
+		notpecl \
+		cp notpecl /mnt/notpecl
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # notpecl
 
-`notpecl` is a little CLI tool to replace the deprecated `pecl` tool. See the
-[Why](#why) section below.
+`notpecl` is a little CLI tool to replace the deprecated `pecl` tool.
 
+* [Why?](#why)
 * [Usage](#usage)
 * [Install](#install)
-* [Why?](#why)
 * [Credits](#credits)
+
+## Why?
+
+The version versions of the official Docker image for PHP 7.4 did not include 
+`pecl` as this tool has been deprecated. However, as there were no working 
+replacement at this time, Docker maintainers decided to include `pecl` in 7.4
+images. See [this issue](https://github.com/docker-library/php/issues/846).
+
+Moreover, as I needed an easy way to resolve version constraints on PHP
+community extensions from a Go tool, [zbuild](https://github.com/NiR-/zbuild),
+the best seemed to build my own tool.
 
 ## Usage
 
-* `download`: Download and unpack extension archives (tgz with a package.xml) ;
-* `build`: Build an extension from its source code ;
 * `install`: Download and build an extension locally. This is the one you 
 probably want to use ;
+* `download`: Download and unpack extension archives (tgz with a package.xml) ;
+* `build`: Build an extension from its source code ;
 
 Like pecl, this tool has an interactive UI for config questions and also
 supports running in noninteractive mode.
@@ -79,10 +89,6 @@ You have to build it by yourself but a proper release will come soon:
 go get github.com/NiR-/notpecl
 go install github.com/NiR-/notpecl
 ```
-
-## Why?
-
-See https://github.com/docker-library/php/issues/846
 
 ## Credits
 


### PR DESCRIPTION
So far notpecl was not completely build statically, as it was still
depending on glibc. It's now build through a Docker image based on
Alpine. As such, it's statically linked with musl and thus doesn't
depend on glibc any more.

This is needed to be able to distribute a single binary compatible with
both Debian and Alpine (which is a nice-to-have for zbuild).