### PR TITLE
Fix php-config path caching

### DIFF
--- a/pecl/backend.go
+++ b/pecl/backend.go
@@ -375,7 +375,6 @@ func (b backend) buildStepConfigure(cmdexec cmdexec.CmdExecutor, opts BuildOpts,
 	}
 
 	args := append(opts.ConfigureArgs, "--with-php-config="+b.phpConfigPath)
-
 	err := cmdexec.Run("./configure", args...)
 	if err != nil {
 		return xerrors.Errorf("failed to run configure: %v", err)
@@ -384,7 +383,7 @@ func (b backend) buildStepConfigure(cmdexec cmdexec.CmdExecutor, opts BuildOpts,
 	return nil
 }
 
-func (b backend) resolvePhpConfigPath() error {
+func (b *backend) resolvePhpConfigPath() error {
 	var err error
 	b.phpConfigPath, err = exec.LookPath("php-config")
 


### PR DESCRIPTION
The method caching the path to php-config was missing a pointer thus,
that path was actually never written back to the backend struct.